### PR TITLE
Update README.md to include safe: server option required for include …

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ export default defineConfig({
     asciidoc({
       options: {
         /* Asciidoctor.js options */
+        safe: "server",
       },
     }),
   ],
@@ -53,6 +54,7 @@ export default defineConfig({
 Add `.adoc` pages to `src/pages/` directory:
 
 ```asciidoc
+// src/pages/demo.adoc
 = Page Title
 :layout: ./src/layouts/Main.astro
 
@@ -67,6 +69,7 @@ Use frontmatter and props in the layout:
 
 ```astro
 ---
+// src/layouts/Main.astro
 import type { MarkdownHeading } from "astro";
 export interface Props {
   title?: string;


### PR DESCRIPTION
Hi @shishkin, Thank you for creating this Asciidoc integration for Astro.

Small PR:
I propose to add the `safe: "server"` option to integration settings, as that is required for the `include::[]` directive to work, which is shown in the demo file. Also added file path as comments to make it unambiguous.

Looking forward to explore further with this.